### PR TITLE
change to github.com/k8s-sqldb-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,16 @@
 FROM golang:1.10.3 as builder
 
 # Copy in the go src
-WORKDIR /go/src/k8s.io/sqldb
+WORKDIR /go/src/github.com/k8s-sqldb-operator
 COPY pkg/    pkg/
 COPY cmd/    cmd/
 COPY vendor/ vendor/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager k8s.io/sqldb/cmd/manager
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/k8s-sqldb-operator/cmd/manager
 
 # Copy the controller-manager into a thin image
 FROM ubuntu:latest
 WORKDIR /root/
-COPY --from=builder /go/src/k8s.io/sqldb/manager .
+COPY --from=builder /go/src/github.com/k8s-sqldb-operator/manager .
 ENTRYPOINT ["./manager"]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test: generate fmt vet manifests
 
 # Build manager binary
 manager: generate fmt vet
-	go build -o bin/manager k8s.io/sqldb/cmd/manager
+	go build -o bin/manager github.com/k8s-sqldb-operator/cmd/manager
 
 alpine-up:
 	kubectl run --generator=run-pod/v1 --image=alpine:latest -it alpine -- /bin/sh

--- a/PROJECT
+++ b/PROJECT
@@ -1,3 +1,3 @@
 version: "1"
 domain: example.com
-repo: k8s.io/sqldb
+repo: github.com/k8s-sqldb-operator

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -19,9 +19,9 @@ package main
 import (
 	"log"
 
+	"github.com/k8s-sqldb-operator/pkg/apis"
+	"github.com/k8s-sqldb-operator/pkg/controller"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"k8s.io/sqldb/pkg/apis"
-	"k8s.io/sqldb/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"

--- a/pkg/apis/addtoscheme_infra_v1alpha1.go
+++ b/pkg/apis/addtoscheme_infra_v1alpha1.go
@@ -17,7 +17,7 @@ limitations under the License.
 package apis
 
 import (
-	"k8s.io/sqldb/pkg/apis/infra/v1alpha1"
+	"github.com/k8s-sqldb-operator/pkg/apis/infra/v1alpha1"
 )
 
 func init() {

--- a/pkg/apis/infra/v1alpha1/doc.go
+++ b/pkg/apis/infra/v1alpha1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the infra v1alpha1 API group
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/sqldb/pkg/apis/infra
+// +k8s:conversion-gen=github.com/k8s-sqldb-operator/pkg/apis/infra
 // +k8s:defaulter-gen=TypeMeta
 // +groupName=infra.example.com
 package v1alpha1

--- a/pkg/apis/infra/v1alpha1/register.go
+++ b/pkg/apis/infra/v1alpha1/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the infra v1alpha1 API group
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/sqldb/pkg/apis/infra
+// +k8s:conversion-gen=github.com/k8s-sqldb-operator/pkg/apis/infra
 // +k8s:defaulter-gen=TypeMeta
 // +groupName=infra.example.com
 package v1alpha1

--- a/pkg/controller/add_sqlbackup.go
+++ b/pkg/controller/add_sqlbackup.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controller
 
 import (
-	"k8s.io/sqldb/pkg/controller/sqlbackup"
+	"github.com/k8s-sqldb-operator/pkg/controller/sqlbackup"
 )
 
 func init() {

--- a/pkg/controller/add_sqldb.go
+++ b/pkg/controller/add_sqldb.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controller
 
 import (
-	"k8s.io/sqldb/pkg/controller/sqldb"
+	"github.com/k8s-sqldb-operator/pkg/controller/sqldb"
 )
 
 func init() {

--- a/pkg/controller/sqlbackup/sqlbackup_controller.go
+++ b/pkg/controller/sqlbackup/sqlbackup_controller.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	infrav1alpha1 "github.com/k8s-sqldb-operator/pkg/apis/infra/v1alpha1"
+	"github.com/k8s-sqldb-operator/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	infrav1alpha1 "k8s.io/sqldb/pkg/apis/infra/v1alpha1"
-	"k8s.io/sqldb/pkg/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"

--- a/pkg/controller/sqlbackup/sqlbackup_controller_suite_test.go
+++ b/pkg/controller/sqlbackup/sqlbackup_controller_suite_test.go
@@ -22,10 +22,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/k8s-sqldb-operator/pkg/apis"
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/sqldb/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/pkg/controller/sqlbackup/sqlbackup_controller_test.go
+++ b/pkg/controller/sqlbackup/sqlbackup_controller_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 	"time"
 
+	infrav1alpha1 "github.com/k8s-sqldb-operator/pkg/apis/infra/v1alpha1"
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	infrav1alpha1 "k8s.io/sqldb/pkg/apis/infra/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/pkg/controller/sqldb/sqldb_controller.go
+++ b/pkg/controller/sqldb/sqldb_controller.go
@@ -22,6 +22,8 @@ import (
 	"log"
 	"strings"
 
+	infrav1alpha1 "github.com/k8s-sqldb-operator/pkg/apis/infra/v1alpha1"
+	"github.com/k8s-sqldb-operator/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -29,8 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	infrav1alpha1 "k8s.io/sqldb/pkg/apis/infra/v1alpha1"
-	"k8s.io/sqldb/pkg/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"

--- a/pkg/controller/sqldb/sqldb_controller_suite_test.go
+++ b/pkg/controller/sqldb/sqldb_controller_suite_test.go
@@ -22,10 +22,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/k8s-sqldb-operator/pkg/apis"
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/sqldb/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/pkg/controller/sqldb/sqldb_controller_test.go
+++ b/pkg/controller/sqldb/sqldb_controller_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 	"time"
 
+	infrav1alpha1 "github.com/k8s-sqldb-operator/pkg/apis/infra/v1alpha1"
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	infrav1alpha1 "k8s.io/sqldb/pkg/apis/infra/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"


### PR DESCRIPTION
This PR fixes the imports by changing them from `k8s.io/sqldb` to `github.com/k8s-sqldb-operator`.

Verified both `make run` and `make install` commands can be run successfully.